### PR TITLE
Remove application from AndroidManifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,11 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="pl.aprilapps.easyphotopicker">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="pl.aprilapps.easyphotopicker">
-</manifest>
+<manifest package="pl.aprilapps.easyphotopicker"/>


### PR DESCRIPTION
There is no need to have <application> in library manifest. 
It could cause "Manifest merger failed".