### PR TITLE
Fix NPE on taking photo from chooser

### DIFF
--- a/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.java
+++ b/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.java
@@ -209,7 +209,7 @@ public class EasyImage implements EasyImageConfig {
                     onPictureReturnedFromGallery(data, activity, callbacks);
                 } else if (requestCode == EasyImageConfig.REQ_TAKE_PICTURE) {
                     onPictureReturnedFromCamera(activity, callbacks);
-                } else if (data == null) {
+                } else if (data == null || data.getData() == null) {
                     onPictureReturnedFromCamera(activity, callbacks);
                 } else {
                     onPictureReturnedFromGallery(data, activity, callbacks);


### PR DESCRIPTION
Taking photo from chooser intent raises NullPointerException on my device (Nexus5X, Android 6.0).
In this case, data is not null but data.getData() returns null.
