### PR TITLE
Fix issue #38

### DIFF
--- a/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImageFiles.java
+++ b/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImageFiles.java
@@ -97,8 +97,13 @@ class EasyImageFiles {
      * @param context context
      */
     public static String getFolderLocation(Context context) {
-        String defaultFolderLocation = publicAppExternalDir(context).getPath();
-        return PreferenceManager.getDefaultSharedPreferences(context).getString(BundleKeys.FOLDER_LOCATION, defaultFolderLocation);
+        File publicAppExternalDir = publicAppExternalDir(context);
+        String defaultFolderLocation = null;
+        if (publicAppExternalDir != null) {
+            defaultFolderLocation = publicAppExternalDir.getPath();
+        }
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(BundleKeys.FOLDER_LOCATION, defaultFolderLocation);
     }
 
     public static File getCameraPicturesLocation(Context context) throws IOException {


### PR DESCRIPTION
Added check if `publicAppExternalDir()` returns null to avoid NPE.
This commit should fix https://github.com/jkwiecien/EasyImage/issues/38