### PR TITLE
Multi image select

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }

--- a/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImageConfig.java
+++ b/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImageConfig.java
@@ -9,4 +9,5 @@ public interface EasyImageConfig {
     int REQ_PICK_PICTURE_FROM_GALLERY = 7458;
     int REQ_TAKE_PICTURE = 7459;
     int REQ_SOURCE_CHOOSER = 7460;
+    int REQ_PICK_MULTI_PICTURE_FROM_GALLERY = 7461;
 }

--- a/sample/src/main/java/pl/aprilapps/easyphotopicker/sample/MainActivity.java
+++ b/sample/src/main/java/pl/aprilapps/easyphotopicker/sample/MainActivity.java
@@ -11,6 +11,7 @@ import android.widget.ImageView;
 import com.squareup.picasso.Picasso;
 
 import java.io.File;
+import java.util.List;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
@@ -133,6 +134,11 @@ public class MainActivity extends AppCompatActivity {
             public void onImagePicked(File imageFile, EasyImage.ImageSource source, int type) {
                 //Handle the image
                 onPhotoReturned(imageFile);
+            }
+
+            @Override
+            public void onMultipleImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
+                // TODO implement
             }
 
             @Override


### PR DESCRIPTION
- Fixes #34 
- If API level is below 18, automatically uses single image select
- Unreliable depending on the gallery application

This is a possible solution for #34. The question is, should the library or the client handle current API below 18 problems? 
I implemented an additional callback `onMultipleImagesPicked`. Maybe it is better to replace `onImagePicked` with the multi image picked callback?
