### PR TITLE
Add FileProvider to support apps targeting Android N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 1.4.0
+
+Features:
+
+  - Library now uses the `FileProvider` class to fully support the [changes introduced in Android N](https://developer.android.com/about/versions/nougat/android-7.0-changes.html#sharing-files), thus preventing he apps targeting API level 24 to throw `FileUriExposedException`.
+    **Behavior change**: pictures taken from camera are now saved in either the external cache directory (if available) or the internal cache directory and it's no longer possible to customize the subfolder.

--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,13 @@ task clean(type: Delete) {
 
 ext {
     // SDK and Tools Versions
-    compileSdkVersion = 23
-    targetSdkVersion = 23
+    compileSdkVersion = 24
+    targetSdkVersion = 24
     buildToolsVersion = "23.0.1"
     minSdkVersion = 14
     versionCode = 10
     versionName = "1.2.1"
 
     // App dependencies
-    supportLibraryVersion = '23.1.1'
+    supportLibraryVersion = '24.2.0'
 }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,1 +1,19 @@
-<manifest package="pl.aprilapps.easyphotopicker"/>
+<manifest package="pl.aprilapps.easyphotopicker"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    >
+
+    <application>
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.easyphotopicker.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true"
+            >
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths"
+                />
+        </provider>
+    </application>
+
+</manifest>

--- a/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImageFiles.java
+++ b/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImageFiles.java
@@ -109,10 +109,22 @@ class EasyImageFiles {
     }
 
     public static File getCameraPicturesLocation(Context context) throws IOException {
-        File dir = new File(EasyImageFiles.getFolderLocation(context), EasyImageFiles.getFolderName(context));
+
+        File cacheDir = context.getCacheDir();
+
+        if (isExternalStorageWritable()) {
+            cacheDir = context.getExternalCacheDir();
+        }
+
+        File dir = new File(cacheDir, DEFAULT_FOLDER_NAME);
         if (!dir.exists()) dir.mkdirs();
         File imageFile = File.createTempFile(UUID.randomUUID().toString(), ".jpg", dir);
         return imageFile;
+    }
+
+    private static boolean isExternalStorageWritable() {
+        String state = Environment.getExternalStorageState();
+        return Environment.MEDIA_MOUNTED.equals(state);
     }
 
     /**

--- a/library/src/main/res/xml/filepaths.xml
+++ b/library/src/main/res/xml/filepaths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-cache-path name="picturesext" path="EasyImage/" />
+    <cache-path name="picturesint" path="EasyImage/" />
+</paths>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,6 +5,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
+        applicationId "pl.aprilapps.easyphotopicker.sample"
         minSdkVersion 15
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode


### PR DESCRIPTION
The library now uses the `FileProvider` class to fully support the [changes introduced in Android N](https://developer.android.com/about/versions/nougat/android-7.0-changes.html#sharing-files), thus preventing the apps targeting API level 24 to throw `FileUriExposedException`.

There is a behavior change: pictures taken from camera are now saved in either the external cache directory (if available) or the internal cache directory and it's no longer possible to customize the subfolder. This is due to the FileProvider API, which want to know in advance what folders are going to be exposed, at least to my understanding.

See issue #60 