### PR TITLE
add grant permission for camera when using document chooser

### DIFF
--- a/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.java
+++ b/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.java
@@ -117,6 +117,7 @@ public class EasyImage implements EasyImageConfig {
             intent.setComponent(new ComponentName(res.activityInfo.packageName, res.activityInfo.name));
             intent.setPackage(packageName);
             intent.putExtra(MediaStore.EXTRA_OUTPUT, outputFileUri);
+            grantWritePermission(context, intent, outputFileUri);
             cameraIntents.add(intent);
         }
         Intent galleryIntent;


### PR DESCRIPTION
you forgot to add this when using EasyImage with chooser