### PR TITLE
Fix #78

### DIFF
--- a/library/src/main/res/xml/filepaths.xml
+++ b/library/src/main/res/xml/filepaths.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-cache-path name="picturesext" path="EasyImage/" />
-    <cache-path name="picturesint" path="EasyImage/" />
+    <root-path name="root" path="." />
 </paths>


### PR DESCRIPTION
`FileProvider` doesn't support removable storage. This is an undocumented workaround.