### PR TITLE
Minor change to support SDK 15 and above

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext {
         compile_sdk_version = 28
         target_sdk_version = 28
-        min_sdk_version = 16
+        min_sdk_version = 15
         version_code = 12
         version_name = "2.1.0"
     }

--- a/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.java
+++ b/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.java
@@ -362,7 +362,11 @@ public class EasyImage implements Constants {
     }
 
     private static boolean isPhoto(Intent data) {
-        return data == null || (data.getData() == null && data.getClipData() == null);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            return data == null || (data.getData() == null && data.getClipData() == null);
+        } else {
+            return data == null || (data.getData() == null);
+        }
     }
 
     public static boolean willHandleActivityResult(int requestCode, int resultCode, Intent data) {
@@ -420,8 +424,11 @@ public class EasyImage implements Constants {
 
     private static void onPictureReturnedFromGallery(Intent data, Activity activity, @NonNull Callbacks callbacks) {
         try {
-            ClipData clipData = data.getClipData();
             List<File> files = new ArrayList<>();
+            ClipData clipData = null;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                clipData = data.getClipData();
+            }
             if (clipData == null) {
                 Uri uri = data.getData();
                 File file = EasyImageFiles.pickedExistingPicture(activity, uri);


### PR DESCRIPTION
Have added handling to support min SDK version 15. 

We are trying to use the library in [Wikimedia Commons app](https://github.com/commons-app/apps-android-commons/) and we got stuck as the library support SDK 16 and above. 

@jkwiecien It would be great if you could share your thoughts on why the SDK version was updated after v.1.3.1. 

Also, let me know if there's an issue with my approach. 
