### PR TITLE
Fix result Intent handling when returning from Chooser with empty Intent

### DIFF
--- a/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.kt
+++ b/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.kt
@@ -245,7 +245,7 @@ class EasyImage private constructor(
 
     private fun onFileReturnedFromChooser(resultIntent: Intent?, activity: Activity, callbacks: Callbacks) {
         Log.d(EASYIMAGE_LOG_TAG, "File returned from chooser")
-        if (resultIntent != null) {
+        if (resultIntent != null && resultIntent.data != null) {
             onPickedExistingPictures(resultIntent, activity, callbacks)
             removeCameraFileAndCleanup()
         } else if (lastCameraFile != null) {


### PR DESCRIPTION
 * Nexus Camera app returns from picture taking with an empty Inent (Intent#data=null)
 * Check if Intent#data is null and if true assume that user has choosen camera to take picture
 * Load camera picture if pending camera file is not null